### PR TITLE
fix initdata/refdata issues causing section mismatches

### DIFF
--- a/arch/arm/mach-msm/ext-buck-control.c
+++ b/arch/arm/mach-msm/ext-buck-control.c
@@ -105,7 +105,7 @@ static struct of_device_id msm_ext_buck_table[] __initdata = {
 	{},
 };
 
-static struct platform_driver msm_ext_buck_driver = {
+static struct platform_driver msm_ext_buck_driver __refdata = {
 	.probe = msm_ext_buck_probe,
 	.driver = {
 		.name = "ext-buck-control",

--- a/arch/arm/mach-msm/gdsc.c
+++ b/arch/arm/mach-msm/gdsc.c
@@ -146,7 +146,7 @@ static struct regulator_ops gdsc_ops = {
 
 static int __devinit gdsc_probe(struct platform_device *pdev)
 {
-	static atomic_t gdsc_count = ATOMIC_INIT(-1);
+	static atomic_t gdsc_count __devinitdata = ATOMIC_INIT(-1);
 	struct regulator_init_data *init_data;
 	struct resource *res;
 	struct gdsc *sc;
@@ -279,7 +279,7 @@ static struct of_device_id gdsc_match_table[] = {
 	{}
 };
 
-static struct platform_driver gdsc_driver = {
+static struct platform_driver gdsc_driver __refdata = {
 	.probe		= gdsc_probe,
 	.remove		= __devexit_p(gdsc_remove),
 	.driver		= {

--- a/arch/arm/mach-msm/krait-regulator-pmic.c
+++ b/arch/arm/mach-msm/krait-regulator-pmic.c
@@ -388,7 +388,7 @@ static int __devinit krait_vreg_pmic_probe(struct spmi_device *spmi)
 	return 0;
 }
 
-static struct spmi_driver qpnp_revid_driver = {
+static struct spmi_driver qpnp_revid_driver __refdata = {
 	.probe	= krait_vreg_pmic_probe,
 	.driver	= {
 		.name		= KRAIT_REG_PMIC_DEV_NAME,

--- a/arch/arm/mach-msm/krait-regulator.c
+++ b/arch/arm/mach-msm/krait-regulator.c
@@ -1405,7 +1405,7 @@ static struct of_device_id krait_power_match_table[] = {
 	{}
 };
 
-static struct platform_driver krait_power_driver = {
+static struct platform_driver krait_power_driver __refdata = {
 	.probe	= krait_power_probe,
 	.remove	= __devexit_p(krait_power_remove),
 	.driver	= {
@@ -1612,7 +1612,7 @@ static int __devexit krait_pdn_remove(struct platform_device *pdev)
 	return 0;
 }
 
-static struct platform_driver krait_pdn_driver = {
+static struct platform_driver krait_pdn_driver __refdata = {
 	.probe	= krait_pdn_probe,
 	.remove	= __devexit_p(krait_pdn_remove),
 	.driver	= {

--- a/arch/arm/mach-msm/lpm_levels.c
+++ b/arch/arm/mach-msm/lpm_levels.c
@@ -1105,7 +1105,7 @@ static struct of_device_id cpu_modes_mtch_tbl[] = {
 	{},
 };
 
-static struct platform_driver cpu_modes_driver = {
+static struct platform_driver cpu_modes_driver __refdata = {
 	.probe = lpm_cpu_probe,
 	.driver = {
 		.name = "cpu-modes",
@@ -1119,7 +1119,7 @@ static struct of_device_id system_modes_mtch_tbl[] = {
 	{},
 };
 
-static struct platform_driver system_modes_driver = {
+static struct platform_driver system_modes_driver __refdata = {
 	.probe = lpm_system_probe,
 	.driver = {
 		.name = "system-modes",
@@ -1133,7 +1133,7 @@ static struct of_device_id lpm_levels_match_table[] = {
 	{},
 };
 
-static struct platform_driver lpm_levels_driver = {
+static struct platform_driver lpm_levels_driver __refdata = {
 	.probe = lpm_probe,
 	.driver = {
 		.name = "lpm-levels",

--- a/arch/arm/mach-msm/msm-pm.c
+++ b/arch/arm/mach-msm/msm-pm.c
@@ -1015,7 +1015,7 @@ static struct of_device_id msm_slp_sts_match_tbl[] = {
 	{},
 };
 
-static struct platform_driver msm_cpu_status_driver = {
+static struct platform_driver msm_cpu_status_driver __refdata = {
 	.probe = msm_cpu_status_probe,
 	.driver = {
 		.name = "cpu_slp_status",
@@ -1029,7 +1029,7 @@ static struct of_device_id msm_snoc_clnt_match_tbl[] = {
 	{},
 };
 
-static struct platform_driver msm_cpu_pm_snoc_client_driver = {
+static struct platform_driver msm_cpu_pm_snoc_client_driver __refdata = {
 	.probe = msm_pm_snoc_client_probe,
 	.driver = {
 		.name = "pm_snoc_client",
@@ -1296,7 +1296,7 @@ static struct of_device_id msm_cpu_pm_table[] = {
 	{},
 };
 
-static struct platform_driver msm_cpu_pm_driver = {
+static struct platform_driver msm_cpu_pm_driver __refdata = {
 	.probe = msm_cpu_pm_probe,
 	.driver = {
 		.name = "pm-8x60",

--- a/arch/arm/mach-msm/rpm-smd.c
+++ b/arch/arm/mach-msm/rpm-smd.c
@@ -1408,7 +1408,7 @@ static struct of_device_id msm_rpm_match_table[] =  {
 	{},
 };
 
-static struct platform_driver msm_rpm_device_driver = {
+static struct platform_driver msm_rpm_device_driver __refdata = {
 	.probe = msm_rpm_dev_probe,
 	.driver = {
 		.name = "rpm-smd",


### PR DESCRIPTION
When building inline, kernel compilation is fine. However, if not building inline, a section mismatch error will pop up. We fix that problem by doing what the error tells us to do, i.e. annotate the variables correctly.

Change-Id: I2785c05350a209733db25d57d0fe2110a6edd0c0

# WE DO NOT MERGE PULL REQUESTS SUBMITTED HERE

You will need to submit it through [LineageOS Gerrit](https://review.lineageos.org/#/admin/projects/LineageOS/android_kernel_sony_msm8974)

